### PR TITLE
Added test and flush file pointer

### DIFF
--- a/Tests/test_file_sgi.py
+++ b/Tests/test_file_sgi.py
@@ -73,6 +73,13 @@ def test_write(tmp_path):
         img.save(out, format="sgi")
         assert_image_equal_tofile(img, out)
 
+        out = str(tmp_path / "fp.sgi")
+        with open(out, "wb") as fp:
+            img.save(fp)
+            assert_image_equal_tofile(img, out)
+
+            assert not fp.closed
+
     for mode in ("L", "RGB", "RGBA"):
         roundtrip(hopper(mode))
 

--- a/src/PIL/SgiImagePlugin.py
+++ b/src/PIL/SgiImagePlugin.py
@@ -193,6 +193,9 @@ def _save(im, fp, filename):
     for channel in im.split():
         fp.write(channel.tobytes("raw", rawmode, 0, orientation))
 
+    if hasattr(fp, "flush"):
+        fp.flush()
+
 
 class SGI16Decoder(ImageFile.PyDecoder):
     _pulls_fd = True


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/5645

I added a test for your change. Then, I found that the test was failing, so I added `flush()`, as [seen in other plugins](https://github.com/python-pillow/Pillow/blob/6cb127c8cdb95cfc5f8e34e6cc686b565526a933/src/PIL/PalmImagePlugin.py#L216-L217).